### PR TITLE
Fix: when clientStore create new client if client already exist, delete it then re-create

### DIFF
--- a/client_store.go
+++ b/client_store.go
@@ -185,13 +185,17 @@ func (cs *ClientStore) Create(info oauth2.ClientInfo) (err error) {
 
 	_, err = collection.InsertOne(ctx, entity)
 	if err != nil {
-		if !mongo.IsDuplicateKeyError(err) {
-			log.Fatal(err)
+		// if an entry already exist, delete it and create a new one
+		if mongo.IsDuplicateKeyError(err) {
+			err = cs.RemoveByID(entity.ID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			return cs.Create(info)
 		} else {
-			return nil
+			log.Fatal(err)
 		}
 	}
-
 	return
 }
 

--- a/token_store.go
+++ b/token_store.go
@@ -160,6 +160,7 @@ func (ts *TokenStore) c(name string) *mongo.Collection {
 
 // Create create and store the new token information
 func (ts *TokenStore) Create(ctx context.Context, info oauth2.TokenInfo) (err error) {
+
 	jv, err := json.Marshal(info)
 	if err != nil {
 		return
@@ -340,6 +341,7 @@ func (ts *TokenStore) getData(basicID string) (ti oauth2.TokenInfo, err error) {
 		return
 	}
 	ti = &tm
+
 	return
 }
 


### PR DESCRIPTION
Hi, a little fix, 
Previously, if a client was registered and subsequently needed to have its credentials modified, the client's existing registration was not updated.

With this fix, if the client's credentials are modified at the registration/creation process, the previous entry will be deleted from the database. Subsequently, a new entry will be created with the updated information.
